### PR TITLE
add BBMD list to scan results

### DIFF
--- a/BACnet-discover-enumerate.nse
+++ b/BACnet-discover-enumerate.nse
@@ -38,7 +38,8 @@ http://digitalbond.com
 --|   Model Name: GNU
 --|   Description: server
 --|   Location: USA
---|_  BBMD: 192.168.0.100:47808
+--|   BBMD: 192.168.0.100:47808
+--|_  FDT: 192.168.1.101:47809:ttl=60:timeout=37
 --
 -- @xmloutput
 --<elem key="Vendor ID">BACnet Stack at SourceForge (260)</elem>
@@ -50,6 +51,7 @@ http://digitalbond.com
 --<elem key="Description">server</elem>
 --<elem key="Location">USA</elem>
 --<elem key="BBMD">192.168.0.100:47808</elem>
+--<elem key="FDT">192.168.1.101:47809:ttl=60:timeout=37</elem>
 
 
 
@@ -950,7 +952,7 @@ end
 -- @param type Type is the type of packet to send, this can be bbmd or fdt
 function bvlc_query(socket, type)
 
-  -- set the BBMD query data for sending
+  -- set the BVLC query data for sending
   local bbmd_query = bin.pack("H","81020004")
   local fdt_query = bin.pack("H","81060004")
 
@@ -963,7 +965,7 @@ function bvlc_query(socket, type)
     query = fdt_query
   end
 
-  --try to pull the  information
+  --try to pull the information
   local status, result = socket:send(query)
   if(status == false) then
     stdnse.print_debug(1, "BVLC-" .. type .. ": Socket error sending query: %s", result)
@@ -1034,7 +1036,7 @@ function bvlc_query(socket, type)
         return nil
       end
 
-      -- build the string
+      -- build the result string
       if firstloop == 1 then
         resultlist = ipaddr
       else


### PR DESCRIPTION
This is probably the ugliest LUA possible... I am new to nse programming
so please be kind :-)  I didn't try to work within the existing
standard_query function because it is laid out for get-property data in
the APDU, but the BBMD table list is returned as part of the BVLC.  I
did borrow the standard-query function layout, and tried to adhere to
the same methodology so the script is somewhat consistent.  I am sure
there is a much more elegant way to do the unpacking, but I don't know
enough Lua yet.

I called the function bbmd_query but it is more appropriately called bvlc_query if there
are other bvlc-level requests we are interested in cataloging.  If not, it might be appropriate
to clean up the process and merge the function with standard_query.  I didnt start within the
standard_query since the bbmd list is a block of encoded IPs, not a string, so the decoding
is quite a bit different.

I tested it with Nmap 6.46 on Windows x64 and Debian x64 against hosts
with 0 bbmd, 1 bbmd and >1 bbmd.  I left what is probably an excessive
amount of debug lines in place, as I am sure I will be testing/improving
it in the near future.  Please please please give feedback.
