### PR TITLE
Declare bin in codesys-v2-discover.nse

### DIFF
--- a/codesys-v2-discover.nse
+++ b/codesys-v2-discover.nse
@@ -3,6 +3,7 @@ local comm   = require "comm"
 local stdnse = require "stdnse"
 local strbuf = require "strbuf"
 local nsedebug = require "nsedebug"
+local bin = require "bin"
 
 description = [[
 


### PR DESCRIPTION
Fix error 
./codesys-v2-discover.nse:59: variable 'bin' is not declared
stack traceback:
        [C]: in function 'error'
        /usr/bin/../share/nmap/nselib/strict.lua:80: in metamethod '__index'
        ./codesys-v2-discover.nse:59: in function <./codesys-v2-discover.nse:57>
        (...tail calls...)
